### PR TITLE
Simplify module design

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # d3-server-side-demo
 
-This demo app uses d3.js to render svg charts on the server-side with node.js.
+This project uses d3.js to render svg charts on the server-side with Node.js.
 
 
 ## Requirements
 
-* Node.js - [http://nodejs.org](http://nodejs.org)
-* GCC Compiler - the d3 node module uses jsdom which requires a C++ compiler:
-[https://github.com/tmpvar/jsdom#contextify](https://github.com/tmpvar/jsdom#contextify)
+* Node.js - [https://nodejs.org/](https://nodejs.org/)
 
 
 ## Getting Started

--- a/app.js
+++ b/app.js
@@ -1,20 +1,16 @@
 const express = require('express');
 const app = express();
 
-
 app.engine('.html', require('ejs').__express);
 app.set('views', __dirname);
 app.set('view engine', 'html');
 
-
 const fixtureData = require('./fixture_data.json');
 app.locals.barChartHelper = require('./bar_chart_helper');
-
 
 app.get('/', function(req, res) {
   res.render('index', { fixtureData: fixtureData });
 });
-
 
 app.listen(3000);
 console.log('listening on port 3000');

--- a/bar_chart.js
+++ b/bar_chart.js
@@ -1,209 +1,109 @@
-const d3 = require('d3');
+const d3 = Object.assign({},
+  require('d3-scale'),
+  require('d3-axis'),
+  require('d3-array')
+);
 
-module.exports = function() {
+class BarChart {
+  constructor({ data, width, height, xAxisLabel, yAxisLabel, containerId }) {
+    this.data = data;
+    this.width = width;
+    this.height = height;
+    this.xAxisLabel = xAxisLabel;
+    this.yAxisLabel = yAxisLabel;
+    this.containerId = containerId;
 
-  let data = [];
+    this.axisLabelMargin = 10;
+    this.margin = {
+      top: 10,
+      right: 10,
+      bottom: 40,
+      left: 40
+    };
+  }
 
-  // const data = [
-  //   {
-  //     'name': '20130601',
-  //     'count': 26
-  //   },
-  //   {
-  //     'name': '20130602',
-  //     'count': 43
-  //   }, ...
-  // ];
+  render(container) {
+    const {
+      data,
+      width,
+      height,
+      xAxisLabel,
+      yAxisLabel,
+      axisLabelMargin,
+      margin
+    } = this;
 
+    const xScale = d3.scaleBand()
+      .domain(this.data.map(({ name }) => name))
+      .rangeRound([0, width - axisLabelMargin - margin.left - margin.right])
+      .padding(0.25);
 
-  // default values for configurable input parameters
-  let width = 400;
-  let height = 300;
-  let margin = {
-    top: 10,
-    right: 10,
-    bottom: 40,
-    left: 40
-  };
-  let xAxisLabel = 'Categories';
-  let yAxisLabel = 'Count';
+    const yScale = d3.scaleLinear()
+      .domain([0, d3.max(data, ({ count }) => count) + 10])
+      .range([height - axisLabelMargin - margin.top - margin.bottom, 0]);
 
+    const xAxis = d3.axisBottom()
+      .scale(xScale)
+      .tickSizeInner(0)
+      .tickSizeOuter(0);
 
-  const chart = function(container) {
+    const yAxis = d3.axisLeft()
+      .tickSizeInner(0)
+      .tickSizeOuter(0)
+      .scale(yScale);
 
-    const axisLabelMargin = 10;
-
-    setupXAxis();
-    setupYAxis();
-    setupBarChartLayout();
-    addBackground();
-    addXAxisLabel();
-    addYAxisLabel();
-    addBarChartData();
-
-
-    var xScale, xAxis, xAxisCssClass;
-
-    function setupXAxis() {
-
-      xScale = d3.scaleBand()
-        .domain(data.map(function(d) {
-          return d.name;
-        }))
-        .rangeRound([0, width - axisLabelMargin - margin.left - margin.right])
-        .padding(0.25);
-
-      if (data.length > 12 && width < 500) {
-        xAxisCssClass = 'axis-font-small';
-      } else {
-        xAxisCssClass = '';
-      }
-
-      xAxis = d3.axisBottom()
-        .scale(xScale)
-        .tickSizeInner(0)
-        .tickSizeOuter(0);
-
-    }
-
-
-    var yScale, yAxis;
-
-    function setupYAxis() {
-
-      yScale = d3.scaleLinear()
-        .domain([0, d3.max(data, function(d) {
-          return d.count;
-        })])
-        .range([height - axisLabelMargin - margin.top - margin.bottom, 0]);
-
-      yAxis = d3.axisLeft()
-        .ticks(5)
-        .tickSizeOuter(0)
-        .scale(yScale);
-
-    }
-
-
-    var g;
-
-    function setupBarChartLayout() {
-
-      g = container.append('svg')
+    const g = container.append('svg')
         .attr('class', 'svg-chart')
         .attr('width', width)
         .attr('height', height)
         .append('g')
         .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
-    }
+    g.append('rect')
+      .attr('class', 'background')
+      .attr('x', axisLabelMargin)
+      .attr('width', width - axisLabelMargin - margin.left - margin.right)
+      .attr('height', height - margin.top - margin.bottom - axisLabelMargin);
 
+    g.append('g')
+      .attr('class', 'x axis')
+      .attr('transform', 'translate(' + axisLabelMargin + ',' +
+        (height - axisLabelMargin - margin.top - margin.bottom) + ')')
+      .call(xAxis)
+      .append('text')
+      .attr('class', 'axis-label')
+      .attr('x', (width - margin.left - margin.right - axisLabelMargin) / 2)
+      .attr('y', margin.left)
+      .style('text-anchor', 'middle')
+      .text(xAxisLabel);
 
-    function addXAxisLabel() {
+    g.append('g')
+      .attr('class', 'y axis')
+      .attr('transform', 'translate(' + axisLabelMargin + ', 0)')
+      .call(yAxis)
+      .append('text')
+      .attr('class', 'axis-label')
+      .attr('transform', 'rotate(-90)')
+      .attr('y', -margin.left)
+      .attr('x', -(height - margin.top - margin.bottom - axisLabelMargin) / 2)
+      .style('text-anchor', 'middle')
+      .text(yAxisLabel);
 
-      g.append('g')
-        .attr('class', 'x axis ' + xAxisCssClass)
-        .attr('transform', 'translate(' + axisLabelMargin + ',' +
-          (height - axisLabelMargin - margin.top - margin.bottom) + ')')
-        .call(xAxis)
-        .append('text')
-        .attr('class', 'axis-label')
-        .attr('x', (width - margin.left - margin.right - axisLabelMargin) / 2)
-        .attr('y', margin.left)
-        .style('text-anchor', 'middle')
-        .text(xAxisLabel);
+    g.selectAll('.bar')
+      .data(data)
+      .enter().append('rect')
+      .attr('class', 'bar')
+      .attr('x', function(d) {
+        return xScale(d.name) + axisLabelMargin;
+      })
+      .attr('y', function(d) {
+        return yScale(d.count);
+      })
+      .attr('width', xScale.bandwidth())
+      .attr('height', function(d) {
+        return height - margin.top - margin.bottom - yScale(d.count) - axisLabelMargin;
+      });
+  }
+}
 
-    }
-
-
-    function addYAxisLabel() {
-
-      g.append('g')
-        .attr('class', 'y axis')
-        .attr('transform', 'translate(' + axisLabelMargin + ', 0)')
-        .call(yAxis)
-        .append('text')
-        .attr('class', 'axis-label')
-        .attr('transform', 'rotate(-90)')
-        .attr('y', -margin.left)
-        .attr('x', -(height - margin.top - margin.bottom - axisLabelMargin) / 2)
-        .style('text-anchor', 'middle')
-        .text(yAxisLabel);
-
-    }
-
-
-    function addBackground() {
-
-      g.append('rect')
-        .attr('class', 'background')
-        .attr('x', axisLabelMargin)
-        .attr('y', -axisLabelMargin)
-        .attr('width', width - axisLabelMargin - margin.left - margin.right)
-        .attr('height', height - margin.top - margin.bottom);
-
-    }
-
-
-    function addBarChartData() {
-
-      g.selectAll('.bar')
-        .data(data)
-        .enter().append('rect')
-        .attr('class', 'bar')
-        .attr('x', function(d) {
-          return xScale(d.name) + axisLabelMargin;
-        })
-        .attr('y', function(d) {
-          return yScale(d.count);
-        })
-        .attr('width', xScale.bandwidth())
-        .attr('height', function(d) {
-          return height - margin.top - margin.bottom - yScale(d.count) - axisLabelMargin;
-        });
-
-
-    }
-
-
-  };
-
-
-  chart.data = function(value) {
-    if (!arguments.length) return data;
-    data = value;
-    return chart;
-  };
-
-  chart.width = function(value) {
-    if (!arguments.length) return width;
-    width = value;
-    return chart;
-  };
-
-  chart.height = function(value) {
-    if (!arguments.length) return height;
-    height = value;
-    return chart;
-  };
-
-  chart.margin = function(value) {
-    if (!arguments.length) return margin;
-    margin = value;
-    return chart;
-  };
-
-  chart.xAxisLabel = function(value) {
-    if (!arguments.length) return xAxisLabel;
-    xAxisLabel = value;
-    return chart;
-  };
-
-  chart.yAxisLabel = function(value) {
-    if (!arguments.length) return yAxisLabel;
-    yAxisLabel = value;
-    return chart;
-  };
-
-  return chart;
-};
+module.exports = BarChart;

--- a/bar_chart_helper.js
+++ b/bar_chart_helper.js
@@ -1,31 +1,25 @@
-const d3 = require('d3');
-const jsdom = require("jsdom");
-const { JSDOM } = jsdom;
-const doc = new JSDOM(`<!DOCTYPE html><body></body>`).window.document;
+const jsdom = require('jsdom');
+const d3 = Object.assign({}, require('d3-selection'));
 const barChart = require('./bar_chart');
 
+const { JSDOM } = jsdom;
+const document = new JSDOM().window.document;
 
-const getBarChart = function (params) {
+function getBarChart(params) {
+  const chart = new barChart(params);
+  const { containerId } = params;
 
-  const chart = barChart()
-    .data(params.data)
-    .width(params.width)
-    .height(params.height)
-    .xAxisLabel(params.xAxisLabel)
-    .yAxisLabel(params.yAxisLabel);
+  d3.select(document.body)
+    .append('div')
+    .attr('id', containerId)
+    .call(chart.render.bind(chart));
 
-
-  d3.select(doc.body).append('div').attr('id', params.containerId).call(chart);
-
-  const selector = params.containerId;
-  const svg = d3.select(doc.getElementById(selector)).node().outerHTML;
-  d3.select(doc.getElementById(selector)).remove();
+  const svg = d3.select(document.getElementById(containerId)).node().outerHTML;
+  d3.select(document.getElementById(containerId)).remove();
 
   return svg;
-
-};
-
+}
 
 module.exports = {
-  getBarChart: getBarChart
+  getBarChart
 };


### PR DESCRIPTION
This module pattern from 2012 around creating reusable charts was originally followed: https://bost.ocks.org/mike/chart/. Coming back to it 8 years later, I find it confusing and overly complex. Replacing it with a `class` for this simple use-case.